### PR TITLE
Switch from script elements to comments and comment elements

### DIFF
--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -9,8 +9,8 @@
       guid = 0,
       document = window.document,
 
-      // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
-      supportsRange = ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
+      // Feature-detect the W3C range API
+      supportsRange = ('createRange' in document) && (typeof Range !== 'undefined'),
 
       throwNotFound = function() {
         throw new Error("Cannot perform operations on a Metamorph that is not in the DOM.");
@@ -56,6 +56,76 @@
     return this.startTag() + this.innerHTML + this.endTag();
   };
 
+  /**
+   * This code is mostly taken from jQuery, with one exception. In jQuery's case, we
+   * have some HTML and we need to figure out how to convert it into some nodes.
+   *
+   * In this case, jQuery needs to scan the HTML looking for an opening tag and use
+   * that as the key for the wrap map. In our case, we know the parent node, and
+   * can use its type as the key for the wrap map.
+   **/
+  var wrapMap = {
+    select: [ 1, "<select multiple='multiple'>", "</select>" ],
+    fieldset: [ 1, "<fieldset>", "</fieldset>" ],
+    table: [ 1, "<table>", "</table>" ],
+    tbody: [ 2, "<table><tbody>", "</tbody></table>" ],
+    tr: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
+    colgroup: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
+    map: [ 1, "<map>", "</map>" ]
+  };
+
+  /**
+   * Given a parent node and some HTML, create a DocumentFragment that contains
+   * the nodes for the HTML.
+   *
+   * We need to do this because innerHTML in IE does not really parse the nodes.
+   **/
+  var fragmentFor = function(parentNode, html) {
+    var element = document.createElement('div'),
+        frag = document.createDocumentFragment(),
+        map, depth, start, end, child;
+
+    if (needsShy) {
+      html = '&shy;' + html;
+    }
+
+    if (map = wrapMap[parentNode.tagName.toLowerCase()]) {
+
+      depth = map[0];
+      start = map[1];
+      end = map[2];
+
+      element.innerHTML = start + html + end;
+
+      while (depth--) {
+        element = element.firstChild;
+      }
+
+    } else {
+      element.innerHTML = html;
+    }
+
+    // Look for &shy; to remove it.
+    if (needsShy) {
+      var shyElement = element.firstChild;
+
+      // Sometimes we get nameless elements with the shy inside
+      while (shyElement.nodeType === 1 && !shyElement.nodeName && shyElement.childNodes.length === 1) {
+        shyElement = shyElement.firstChild;
+      }
+
+      // At this point it's the actual unicode character.
+      if (shyElement.nodeType === 3 && shyElement.nodeValue.charAt(0) === "\u00AD") {
+        shyElement.nodeValue = shyElement.nodeValue.slice(1);
+      }
+    }
+
+    while (child = element.firstChild) {
+      frag.appendChild(child);
+    }
+    return frag;
+  };
+
   // If we have the W3C range API, this process is relatively straight forward.
   if (supportsRange) {
 
@@ -70,11 +140,7 @@
     // IE 9 supports ranges but doesn't define createContextualFragment
     if (!Range.prototype.createContextualFragment) {
       Range.prototype.createContextualFragment = function(html) {
-        var frag = document.createDocumentFragment(),
-             div = document.createElement("div");
-        frag.appendChild(div);
-        div.outerHTML = html;
-        return frag;
+        return fragmentFor(this.startContainer, html);
       };
     }
 
@@ -98,7 +164,8 @@
 
       // Comment nodes may continue to exist even if they have been removed from
       // the document. Thus, make sure they are still somewhere in the body.
-      return (document.body.compareDocumentPosition(marker) & 16) && marker;
+      return marker && (document.body.compareDocumentPosition(marker) & 16) ?
+        marker : null;
     };
 
     // Get a range for the current morph. Optionally include the starting and
@@ -232,62 +299,6 @@
     }
 
     /**
-     * This code is mostly taken from jQuery, with one exception. In jQuery's case, we
-     * have some HTML and we need to figure out how to convert it into some nodes.
-     *
-     * In this case, jQuery needs to scan the HTML looking for an opening tag and use
-     * that as the key for the wrap map. In our case, we know the parent node, and
-     * can use its type as the key for the wrap map.
-     **/
-    var wrapMap = {
-      select: [ 1, "<select multiple='multiple'>", "</select>" ],
-      fieldset: [ 1, "<fieldset>", "</fieldset>" ],
-      table: [ 1, "<table>", "</table>" ],
-      tbody: [ 2, "<table><tbody>", "</tbody></table>" ],
-      tr: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
-      colgroup: [ 2, "<table><tbody></tbody><colgroup>", "</colgroup></table>" ],
-      map: [ 1, "<map>", "</map>" ],
-      _default: [ 0, "", "" ]
-    };
-
-    /**
-     * Given a parent node and some HTML, generate a set of nodes. Return the first
-     * node, which will allow us to traverse the rest using nextSibling.
-     *
-     * We need to do this because innerHTML in IE does not really parse the nodes.
-     **/
-    var firstNodeFor = function(parentNode, html) {
-      var arr = wrapMap[parentNode.tagName.toLowerCase()] || wrapMap._default;
-      var depth = arr[0], start = arr[1], end = arr[2];
-
-      if (needsShy) { html = '&shy;'+html; }
-
-      var element = document.createElement('div');
-      element.innerHTML = start + html + end;
-
-      for (var i=0; i<=depth; i++) {
-        element = element.firstChild;
-      }
-
-      // Look for &shy; to remove it.
-      if (needsShy) {
-        var shyElement = element;
-
-        // Sometimes we get nameless elements with the shy inside
-        while (shyElement.nodeType === 1 && !shyElement.nodeName && shyElement.childNodes.length === 1) {
-          shyElement = shyElement.firstChild;
-        }
-
-        // At this point it's the actual unicode character.
-        if (shyElement.nodeType === 3 && shyElement.nodeValue.charAt(0) === "\u00AD") {
-          shyElement.nodeValue = shyElement.nodeValue.slice(1);
-        }
-      }
-
-      return element;
-    };
-
-    /**
      * In some cases, Internet Explorer can create an anonymous node in
      * the hierarchy with no tagName. You can create this scenario via:
      *
@@ -376,17 +387,18 @@
         throwNotFound();
       }
 
-      var parentNode = end.parentNode;
-      var node, nextSibling, last;
-
       // make sure that the start and end nodes share the same
       // parent. If not, fix it.
       fixParentage(start, end);
 
+      var parentNode = end.parentNode,
+          nextSibling = start.nextSibling,
+          node, last;
+
       // remove all of the nodes after the starting placeholder and
       // before the ending placeholder.
-      node = start.nextSibling;
-      while (node) {
+      while (node = nextSibling) {
+
         nextSibling = node.nextSibling;
         last = node === end;
 
@@ -407,22 +419,13 @@
         // (because we wanted to remove the outer nodes), break
         // now.
         if (last) { break; }
-
-        node = nextSibling;
       }
 
-      // get the first node for the HTML string, even in cases like
+      // Get a DocumentFragment for the content, even in cases like
       // tables and lists where a simple innerHTML on a div would
-      // swallow some of the content.
-      node = firstNodeFor(start.parentNode, html);
-
-      // copy the nodes for the HTML between the starting and ending
-      // placeholder.
-      while (node) {
-        nextSibling = node.nextSibling;
-        parentNode.insertBefore(node, end);
-        node = nextSibling;
-      }
+      // swallow some of it.
+      var frag = fragmentFor(start.parentNode, html);
+      parentNode.insertBefore(frag, end);
     };
 
     // remove the nodes in the DOM representing this metamorph.
@@ -441,13 +444,8 @@
     };
 
     appendToFunc = function(parentNode) {
-      var node = firstNodeFor(parentNode, this.outerHTML());
-
-      while (node) {
-        nextSibling = node.nextSibling;
-        parentNode.appendChild(node);
-        node = nextSibling;
-      }
+      var frag = fragmentFor(parentNode, this.outerHTML());
+      parentNode.appendChild(frag);
     };
 
     afterFunc = function(html) {
@@ -456,22 +454,9 @@
         throwNotFound();
       }
 
-      var parentNode = end.parentNode;
-      var nextSibling;
-      var node;
-
-      // get the first node for the HTML string, even in cases like
-      // tables and lists where a simple innerHTML on a div would
-      // swallow some of the content.
-      node = firstNodeFor(parentNode, html);
-
-      // copy the nodes for the HTML between the starting and ending
-      // placeholder.
-      while (node) {
-        nextSibling = node.nextSibling;
-        parentNode.insertBefore(node, end.nextSibling);
-        node = nextSibling;
-      }
+      var parentNode = end.parentNode,
+          frag = fragmentFor(parentNode, html);
+      parentNode.insertBefore(frag, end.nextSibling);
     };
 
     prependFunc = function(html) {
@@ -480,18 +465,9 @@
         throwNotFound();
       }
 
-      var parentNode = start.parentNode;
-      var nextSibling;
-      var node;
-
-      node = firstNodeFor(parentNode, html);
-      var insertBefore = start.nextSibling;
-
-      while (node) {
-        nextSibling = node.nextSibling;
-        parentNode.insertBefore(node, insertBefore);
-        node = nextSibling;
-      }
+      var parentNode = start.parentNode,
+          frag = fragmentFor(parentNode, html);
+      parentNode.insertBefore(frag, start.nextSibling);
     };
 
     isRemovedFunc = function() {

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -12,6 +12,10 @@
       // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
       supportsRange = ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
 
+      throwNotFound = function() {
+        throw new Error("Cannot perform operations on a Metamorph that is not in the DOM.");
+      },
+
       // Internet Explorer prior to 9 does not allow setting innerHTML if the first element
       // is a "zero-scope" element. This problem can be worked around by making
       // the first node an invisible text node. We, like Modernizr, use &shy;
@@ -76,17 +80,13 @@
 
     var markers = {};
 
-    var inBody = function(node) {
-      return !!(node && (document.body.compareDocumentPosition(node) & 16));
-    };
-
     var getMarker = function(name) {
       var marker = markers[name],
           commentIterator, comment;
 
       // Find marker nodes if not cached already
       if (!marker) {
-        // NodeFilter.SHOW_COMMENT == 128
+        // NodeFilter.SHOW_COMMENT === 128
         commentIterator = document.createTreeWalker(
           document.body, 128, null, false
         );
@@ -98,12 +98,7 @@
 
       // Comment nodes may continue to exist even if they have been removed from
       // the document. Thus, make sure they are still somewhere in the body.
-      if (!inBody(marker)) {
-        delete markers[name];
-        return;
-      }
-
-      return marker;
+      return (document.body.compareDocumentPosition(marker) & 16) && marker;
     };
 
     // Get a range for the current morph. Optionally include the starting and
@@ -114,7 +109,6 @@
           range = document.createRange();
 
       if (start && end) {
-
         if (outerToo) {
           range.setStartBefore(start);
           range.setEndAfter(end);
@@ -129,6 +123,9 @@
     htmlFunc = function(html, outerToo) {
       // get a range for the current metamorph object
       var range = rangeFor(this, outerToo);
+      if (!range) {
+        throwNotFound();
+      }
 
       // delete the contents of the range, which will be the
       // nodes between the starting and ending placeholder.
@@ -145,6 +142,9 @@
       // get a range for the current metamorph object including
       // the starting and ending placeholders.
       var range = rangeFor(this, true);
+      if (!range) {
+        throwNotFound();
+      }
 
       // delete the entire range.
       range.deleteContents();
@@ -161,6 +161,9 @@
     afterFunc = function(html) {
       var range = document.createRange();
       var end = getMarker(this.end);
+      if (!end) {
+        throwNotFound();
+      }
 
       range.setStartAfter(end);
       range.setEndAfter(end);
@@ -172,6 +175,9 @@
     prependFunc = function(html) {
       var range = document.createRange();
       var start = getMarker(this.start);
+      if (!start) {
+        throwNotFound();
+      }
 
       range.setStartAfter(start);
       range.setEndAfter(start);
@@ -186,7 +192,7 @@
 
   } else {
 
-    if (document.createElement('comment').length == 0) {
+    if (document.createElement('comment').length === 0) {
       // Will be true in only IE6-8, which support the comment element. Comment
       // elements in IE6-8 have a length property that returns the number of
       // characters in the comment data. Other browsers will return undefined.
@@ -355,7 +361,7 @@
         nodes = select.childNodes;
         j = 0;
         while (node = nodes[j++]) {
-          // Node.TEXT_NODE == 3
+          // Node.TEXT_NODE === 3
           if (node.nodeType === 3 && node.nodeValue === name) {
             return node;
           }
@@ -366,6 +372,10 @@
     htmlFunc = function(html, outerToo) {
       var start = getMarker(this.start);
       var end = getMarker(this.end);
+      if (!start || !end) {
+        throwNotFound();
+      }
+
       var parentNode = end.parentNode;
       var node, nextSibling, last;
 
@@ -421,6 +431,9 @@
     removeFunc = function() {
       var start = getMarker(this.start);
       var end = getMarker(this.end);
+      if (!start || !end) {
+        throwNotFound();
+      }
 
       this.html('');
       start.parentNode.removeChild(start);
@@ -439,6 +452,10 @@
 
     afterFunc = function(html) {
       var end = getMarker(this.end);
+      if (!end) {
+        throwNotFound();
+      }
+
       var parentNode = end.parentNode;
       var nextSibling;
       var node;
@@ -459,6 +476,10 @@
 
     prependFunc = function(html) {
       var start = getMarker(this.start);
+      if (!start) {
+        throwNotFound();
+      }
+
       var parentNode = start.parentNode;
       var nextSibling;
       var node;
@@ -482,8 +503,7 @@
   }
 
   Metamorph.prototype.html = function(html) {
-    this.checkRemoved();
-    if (html === undefined) { return this.innerHTML; }
+    if (arguments.length === 0) { return this.innerHTML; }
 
     htmlFunc.call(this, html);
 
@@ -491,7 +511,6 @@
   };
 
   Metamorph.prototype.replaceWith = function(html) {
-    this.checkRemoved();
     htmlFunc.call(this, html, true);
   };
 
@@ -503,12 +522,6 @@
   Metamorph.prototype.startTag = startTagFunc;
   Metamorph.prototype.endTag = endTagFunc;
   Metamorph.prototype.isRemoved = isRemovedFunc;
-
-  Metamorph.prototype.checkRemoved = function() {
-    if (this.isRemoved()) {
-      throw new Error("Cannot perform operations on a Metamorph that is not in the DOM.");
-    }
-  };
 
   window.Metamorph = Metamorph;
 })(this);

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -61,35 +61,8 @@
 
   var htmlFunc, removeFunc, outerHTMLFunc, appendToFunc, afterFunc, prependFunc, startTagFunc, endTagFunc, isRemovedFunc;
 
-  if (supportsCommentsInSelect) {
-    outerHTMLFunc = function() {
-      return this.startTag() + this.innerHTML + this.endTag();
-    };
-  } else {
-    outerHTMLFunc = function(forSelect) {
-      if (forSelect) {
-        return this.start + this.innerHTML + this.end;
-      } else {
-        return this.startTag() + this.innerHTML + this.endTag();
-      }
-    };
-  }
-
-  // IE requires text node markers, since it removes comments that are children
-  // of text nodes.
-  var getSelectMarker = function(name) {
-    var selects = document.getElementsByTagName("select"),
-        i = 0, select, nodes, node, j;
-    while (select = selects[i++]) {
-      nodes = select.childNodes;
-      j = 0;
-      while (node = nodes[j++]) {
-        // Node.TEXT_NODE === 3
-        if (node.nodeType === 3 && node.nodeValue === name) {
-          return node;
-        }
-      }
-    }
+  outerHTMLFunc = function() {
+    return this.startTag() + this.innerHTML + this.endTag();
   };
 
   /**
@@ -165,13 +138,38 @@
   // If we have the W3C range API, this process is relatively straight forward.
   if (supportsRange) {
 
-    startTagFunc = function() {
-      return "<!--" + this.start + "-->";
-    };
+    if (supportsCommentsInSelect) {
 
-    endTagFunc = function() {
-      return "<!--" + this.end + "-->";
-    };
+      startTagFunc = function() {
+        return "<!--" + this.start + "-->";
+      };
+      endTagFunc = function() {
+        return "<!--" + this.end + "-->";
+      };
+
+    } else {
+
+      // IE9 will strip out comments that are inserted as children of select elements
+      // via innerHTML, but it will allow the comments to be created via the DOM API.
+      // Thus, in IE9, use script tags for all markers, and then immeditately replace
+      // them with comment nodes as they are inserted into the DOM.
+
+      document.addEventListener('DOMNodeInserted', function(e) {
+        var el = e.target;
+        if (el.type === "text/x-placeholder") {
+          var marker = document.createComment(el.id);
+          el.parentNode.replaceChild(marker, el);
+        }
+      });
+
+      startTagFunc = function() {
+        return "<script id='" + this.start + "' type='text/x-placeholder'></script>";
+      };
+      endTagFunc = function() {
+        return "<script id='" + this.end + "' type='text/x-placeholder'></script>";
+      };
+
+    }
 
     // IE 9 supports ranges but doesn't define createContextualFragment
     if (!Range.prototype.createContextualFragment) {
@@ -195,7 +193,7 @@
         while (comment = commentIterator.nextNode()) {
           markers[comment.data] = comment;
         }
-        marker = markers[name] || getSelectMarker(name);
+        marker = markers[name];
       }
 
       // Comment nodes may continue to exist even if they have been removed from
@@ -389,7 +387,6 @@
       }
     };
 
-
     var getMarker = function(name) {
       var marker = document.getElementById(name);
       if (marker) {
@@ -398,7 +395,18 @@
       }
 
       // If a comment marker is not found, try to find a text marker in a select
-      return getSelectMarker(name);
+      var selects = document.getElementsByTagName("select"),
+          i = 0, select, nodes, node, j;
+      while (select = selects[i++]) {
+        nodes = select.childNodes;
+        j = 0;
+        while (node = nodes[j++]) {
+          // Node.TEXT_NODE === 3
+          if (node.nodeType === 3 && node.nodeValue === name) {
+            return node;
+          }
+        }
+      }
     };
 
     htmlFunc = function(html, outerToo) {

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -118,7 +118,7 @@
 
     appendToFunc = function(node) {
       var range = document.createRange();
-      range.setStart(node);
+      range.setStart(node, 0);
       range.collapse(false);
       var frag = range.createContextualFragment(this.outerHTML());
       node.appendChild(frag);

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -46,22 +46,22 @@
 
   K.prototype = Metamorph.prototype;
 
-  var rangeFor, htmlFunc, removeFunc, outerHTMLFunc, appendToFunc, afterFunc, prependFunc, startTagFunc, endTagFunc;
+  var htmlFunc, removeFunc, outerHTMLFunc, appendToFunc, afterFunc, prependFunc, startTagFunc, endTagFunc, isRemovedFunc;
 
   outerHTMLFunc = function() {
     return this.startTag() + this.innerHTML + this.endTag();
   };
 
-  startTagFunc = function() {
-    return "<script id='" + this.start + "' type='text/x-placeholder'></script>";
-  };
-
-  endTagFunc = function() {
-    return "<script id='" + this.end + "' type='text/x-placeholder'></script>";
-  };
-
   // If we have the W3C range API, this process is relatively straight forward.
   if (supportsRange) {
+
+    startTagFunc = function() {
+      return "<!--" + this.start + "-->";
+    };
+
+    endTagFunc = function() {
+      return "<!--" + this.end + "-->";
+    };
 
     // IE 9 supports ranges but doesn't define createContextualFragment
     if (!Range.prototype.createContextualFragment) {
@@ -74,22 +74,56 @@
       };
     }
 
-    // Get a range for the current morph. Optionally include the starting and
-    // ending placeholders.
-    rangeFor = function(morph, outerToo) {
-      var range = document.createRange();
-      var before = document.getElementById(morph.start);
-      var after = document.getElementById(morph.end);
+    var markers = {};
 
-      if (outerToo) {
-        range.setStartBefore(before);
-        range.setEndAfter(after);
-      } else {
-        range.setStartAfter(before);
-        range.setEndBefore(after);
+    var inBody = function(node) {
+      return !!(node && (document.body.compareDocumentPosition(node) & 16));
+    };
+
+    var getMarker = function(name) {
+      var marker = markers[name],
+          commentIterator, comment;
+
+      // Find marker nodes if not cached already
+      if (!marker) {
+        // NodeFilter.SHOW_COMMENT == 128
+        commentIterator = document.createTreeWalker(
+          document.body, 128, null, false
+        );
+        while (comment = commentIterator.nextNode()) {
+          markers[comment.data] = comment;
+        }
+        marker = markers[name];
       }
 
-      return range;
+      // Comment nodes may continue to exist even if they have been removed from
+      // the document. Thus, make sure they are still somewhere in the body.
+      if (!inBody(marker)) {
+        delete markers[name];
+        return;
+      }
+
+      return marker;
+    };
+
+    // Get a range for the current morph. Optionally include the starting and
+    // ending placeholders.
+    var rangeFor = function(morph, outerToo) {
+      var start = getMarker(morph.start),
+          end = getMarker(morph.end),
+          range = document.createRange();
+
+      if (start && end) {
+
+        if (outerToo) {
+          range.setStartBefore(start);
+          range.setEndAfter(end);
+        } else {
+          range.setStartAfter(start);
+          range.setEndBefore(end);
+        }
+        return range;
+      }
     };
 
     htmlFunc = function(html, outerToo) {
@@ -126,10 +160,10 @@
 
     afterFunc = function(html) {
       var range = document.createRange();
-      var after = document.getElementById(this.end);
+      var end = getMarker(this.end);
 
-      range.setStartAfter(after);
-      range.setEndAfter(after);
+      range.setStartAfter(end);
+      range.setEndAfter(end);
 
       var fragment = range.createContextualFragment(html);
       range.insertNode(fragment);
@@ -137,7 +171,7 @@
 
     prependFunc = function(html) {
       var range = document.createRange();
-      var start = document.getElementById(this.start);
+      var start = getMarker(this.start);
 
       range.setStartAfter(start);
       range.setEndAfter(start);
@@ -146,7 +180,51 @@
       range.insertNode(fragment);
     };
 
+    isRemovedFunc = function() {
+      return rangeFor(this) == null;
+    };
+
   } else {
+
+    if (document.createElement('comment').length == 0) {
+      // Will be true in only IE6-8, which support the comment element. Comment
+      // elements in IE6-8 have a length property that returns the number of
+      // characters in the comment data. Other browsers will return undefined.
+
+      // Even though comment elements support the element API, they act like an
+      // HTML comment during rendering; neither comment elements nor their
+      // children are rendered, and they do not affect CSS selectors.
+
+      // Note that the id is both included on the comment element itself as well
+      // as inside the comment element. This is for the case of markers in
+      // select elements. See getMarker() below for more info.
+
+      startTagFunc = function() {
+        // The empty script tag at the beginning is a hack that somehow keeps
+        // IE from removing the comment node when being inserted via innerHTML.
+        // Instead, the script tag will be removed and only the comment will be
+        // inserted. This is consistent in IE6-8.
+        return "<script></script><comment id='" + this.start + "'>" + this.start + "</comment>";
+      };
+
+      endTagFunc = function() {
+        return "<comment id='" + this.end + "'>" + this.end + "</comment>";
+      };
+
+    } else {
+      // Just in case, fallback to a script element. This shouldn't happen in any
+      // commonly used browser.
+
+      startTagFunc = function() {
+        return "<script id='" + this.start + "' type='text/x-placeholder'></script>";
+      };
+
+      endTagFunc = function() {
+        return "<script id='" + this.end + "' type='text/x-placeholder'></script>";
+      };
+
+    }
+
     /**
      * This code is mostly taken from jQuery, with one exception. In jQuery's case, we
      * have some HTML and we need to figure out how to convert it into some nodes.
@@ -256,10 +334,38 @@
       }
     };
 
+
+    var getMarker = function(name) {
+      var marker = document.getElementById(name);
+      if (marker) {
+        // Get the real starting node. See realNode for details.
+        return realNode(marker);
+      }
+
+      // IE removes comment elements and html comments that are children of
+      // select elements, but it turns their contents into a text node. These
+      // text nodes are not rendered, but they can be accessed as childNodes.
+      // Since this only happens to children of select elements, it is possible
+      // to find the comment markers via document.getElementById() in most
+      // cases, and the fallback test for a marker in a select element should
+      // be reasonably efficient.
+      var selects = document.getElementsByTagName("select"),
+          i = 0, select, nodes, node, j;
+      while (select = selects[i++]) {
+        nodes = select.childNodes;
+        j = 0;
+        while (node = nodes[j++]) {
+          // Node.TEXT_NODE == 3
+          if (node.nodeType === 3 && node.nodeValue === name) {
+            return node;
+          }
+        }
+      }
+    };
+
     htmlFunc = function(html, outerToo) {
-      // get the real starting node. see realNode for details.
-      var start = realNode(document.getElementById(this.start));
-      var end = document.getElementById(this.end);
+      var start = getMarker(this.start);
+      var end = getMarker(this.end);
       var parentNode = end.parentNode;
       var node, nextSibling, last;
 
@@ -313,8 +419,8 @@
     //
     // this includes the starting and ending placeholders.
     removeFunc = function() {
-      var start = realNode(document.getElementById(this.start));
-      var end = document.getElementById(this.end);
+      var start = getMarker(this.start);
+      var end = getMarker(this.end);
 
       this.html('');
       start.parentNode.removeChild(start);
@@ -332,8 +438,7 @@
     };
 
     afterFunc = function(html) {
-      // get the real starting node. see realNode for details.
-      var end = document.getElementById(this.end);
+      var end = getMarker(this.end);
       var parentNode = end.parentNode;
       var nextSibling;
       var node;
@@ -353,7 +458,7 @@
     };
 
     prependFunc = function(html) {
-      var start = document.getElementById(this.start);
+      var start = getMarker(this.start);
       var parentNode = start.parentNode;
       var nextSibling;
       var node;
@@ -366,7 +471,14 @@
         parentNode.insertBefore(node, insertBefore);
         node = nextSibling;
       }
-    }
+    };
+
+    isRemovedFunc = function() {
+      var before = getMarker(this.start);
+      var after = getMarker(this.end);
+
+      return !before || !after;
+    };
   }
 
   Metamorph.prototype.html = function(html) {
@@ -390,13 +502,7 @@
   Metamorph.prototype.prepend = prependFunc;
   Metamorph.prototype.startTag = startTagFunc;
   Metamorph.prototype.endTag = endTagFunc;
-
-  Metamorph.prototype.isRemoved = function() {
-    var before = document.getElementById(this.start);
-    var after = document.getElementById(this.end);
-
-    return !before || !after;
-  };
+  Metamorph.prototype.isRemoved = isRemovedFunc;
 
   Metamorph.prototype.checkRemoved = function() {
     if (this.isRemoved()) {

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -12,10 +12,6 @@
       // Feature-detect the W3C range API
       supportsRange = ('createRange' in document) && (typeof Range !== 'undefined'),
 
-      throwNotFound = function() {
-        throw new Error("Cannot perform operations on a Metamorph that is not in the DOM.");
-      },
-
       // Internet Explorer prior to 9 does not allow setting innerHTML if the first element
       // is a "zero-scope" element. This problem can be worked around by making
       // the first node an invisible text node. We, like Modernizr, use &shy;
@@ -24,8 +20,21 @@
         testEl.innerHTML = "<div></div>";
         testEl.firstChild.innerHTML = "<script></script>";
         return testEl.firstChild.innerHTML === '';
-      })();
+      })(),
 
+      // IE including 9 will remove any comment nodes that are children of
+      // select elements when it parses HTML. In these cases, we need to use
+      // text node markers instead of comment markers.
+      supportsCommentsInSelect = (function() {
+        var testEl = document.createElement('div');
+        testEl.innerHTML = "<select><!----></select>";
+        return testEl.firstChild.childNodes.length === 1;
+      })(),
+
+      throwNotFound = function() {
+        throw new Error("Cannot perform operations on a Metamorph that is not in the DOM.");
+      };
+  
   // Constructor that supports either Metamorph('foo') or new
   // Metamorph('foo');
   // 
@@ -52,8 +61,35 @@
 
   var htmlFunc, removeFunc, outerHTMLFunc, appendToFunc, afterFunc, prependFunc, startTagFunc, endTagFunc, isRemovedFunc;
 
-  outerHTMLFunc = function() {
-    return this.startTag() + this.innerHTML + this.endTag();
+  if (supportsCommentsInSelect) {
+    outerHTMLFunc = function() {
+      return this.startTag() + this.innerHTML + this.endTag();
+    };
+  } else {
+    outerHTMLFunc = function(forSelect) {
+      if (forSelect) {
+        return this.start + this.innerHTML + this.end;
+      } else {
+        return this.startTag() + this.innerHTML + this.endTag();
+      }
+    };
+  }
+
+  // IE requires text node markers, since it removes comments that are children
+  // of text nodes.
+  var getSelectMarker = function(name) {
+    var selects = document.getElementsByTagName("select"),
+        i = 0, select, nodes, node, j;
+    while (select = selects[i++]) {
+      nodes = select.childNodes;
+      j = 0;
+      while (node = nodes[j++]) {
+        // Node.TEXT_NODE === 3
+        if (node.nodeType === 3 && node.nodeValue === name) {
+          return node;
+        }
+      }
+    }
   };
 
   /**
@@ -159,7 +195,7 @@
         while (comment = commentIterator.nextNode()) {
           markers[comment.data] = comment;
         }
-        marker = markers[name];
+        marker = markers[name] || getSelectMarker(name);
       }
 
       // Comment nodes may continue to exist even if they have been removed from
@@ -270,7 +306,9 @@
 
       // Note that the id is both included on the comment element itself as well
       // as inside the comment element. This is for the case of markers in
-      // select elements. See getMarker() below for more info.
+      // select elements. IE removes comments that are children of select
+      // elements, but it turns the contents of comment elements into a text
+      // node. These nodes are not rendered and can be accessed as childNodes.
 
       startTagFunc = function() {
         // The empty script tag at the beginning is a hack that somehow keeps
@@ -359,25 +397,8 @@
         return realNode(marker);
       }
 
-      // IE removes comment elements and html comments that are children of
-      // select elements, but it turns their contents into a text node. These
-      // text nodes are not rendered, but they can be accessed as childNodes.
-      // Since this only happens to children of select elements, it is possible
-      // to find the comment markers via document.getElementById() in most
-      // cases, and the fallback test for a marker in a select element should
-      // be reasonably efficient.
-      var selects = document.getElementsByTagName("select"),
-          i = 0, select, nodes, node, j;
-      while (select = selects[i++]) {
-        nodes = select.childNodes;
-        j = 0;
-        while (node = nodes[j++]) {
-          // Node.TEXT_NODE === 3
-          if (node.nodeType === 3 && node.nodeValue === name) {
-            return node;
-          }
-        }
-      }
+      // If a comment marker is not found, try to find a text marker in a select
+      return getSelectMarker(name);
     };
 
     htmlFunc = function(html, outerToo) {

--- a/tests/metamorph_test.js
+++ b/tests/metamorph_test.js
@@ -58,6 +58,26 @@ test("it should allow you to remove the entire morph from the page", function() 
   });
 });
 
+test("it should allow inserting multiple morphs as html", function() {
+  var morph1 = Metamorph("<b>hi</b>"),
+      morph2 = Metamorph("<i>ho</i>");
+  $("#qunit-fixture").html("<span id='morphing'>" + morph1.outerHTML() + " - " + morph2.outerHTML() + "</span>");
+
+  equal($("#morphing b").html(), "hi", "precond - Should include the contents");
+  equal($("#morphing i").html(), "ho", "precond - Should include the contents");
+
+  morph1.html("<b>away</b>");
+  morph2.html("<i>we go</i>");
+
+  equal($("#morphing b").html(), "away", "precond - Should include the new contents");
+  equal($("#morphing i").html(), "we go", "precond - Should include the new contents");
+
+  morph1.remove();
+  morph2.remove();
+
+  equal($("#morphing").html(), " - ", "Should leave no trace of morphs");
+});
+
 test("it should work inside a table", function() {
   var morph = Metamorph("<tr><td>HI!</td></tr>");
   $("#qunit-fixture").html("<table id='morphing'>" + morph.outerHTML() + "</table>");

--- a/tests/metamorph_test.js
+++ b/tests/metamorph_test.js
@@ -138,7 +138,10 @@ test("it should work inside a ul", function() {
 
 test("it should work inside a select", function() {
   var morph = Metamorph("<option>HI!</option>");
-  $("#qunit-fixture").html("<select id='morphing'>" + morph.outerHTML() + "</select>");
+
+  // Note that IE9 requires that the `forSelect` argument of outerHTML be true
+  // when the morph is used as a child of a select element
+  $("#qunit-fixture").html("<select id='morphing'>" + morph.outerHTML(true) + "</select>");
 
   ok($("#morphing option").text().match(/^\s*HI!\s*$/), "precond - Should include the contents");
 

--- a/tests/metamorph_test.js
+++ b/tests/metamorph_test.js
@@ -138,10 +138,7 @@ test("it should work inside a ul", function() {
 
 test("it should work inside a select", function() {
   var morph = Metamorph("<option>HI!</option>");
-
-  // Note that IE9 requires that the `forSelect` argument of outerHTML be true
-  // when the morph is used as a child of a select element
-  $("#qunit-fixture").html("<select id='morphing'>" + morph.outerHTML(true) + "</select>");
+  $("#qunit-fixture").html("<select id='morphing'>" + morph.outerHTML() + "</select>");
 
   ok($("#morphing option").text().match(/^\s*HI!\s*$/), "precond - Should include the contents");
 


### PR DESCRIPTION
It required a series of crazy IE hacks, but I figured out how to make comments work in all browsers.

The advantages to comments are:
- They don't affect sibling CSS selectors, while script tags do. For example, `+`, `:first-child`, and `:nth-child()` can all be messed up by using script markers.
- DOM traversal methods that only operate on elements will ignore comment markers but not script markers
- HTML comments are valid anywhere, whereas script elements are not even though they work

First, regular comments can be pulled out quickly in IE9 and all other browsers via document.createTreeWalker. This method is actually equivalent to using document.createNodeIterator on comment nodes, because they can't have children. The advantage to createTreeWalker is that it is supported in old versions of Firefox (works in 2.0; didn't bother to test in anything older), whereas createNodeIterator wasn't implemented until Firefox 3.5.

IE 6-8, of course, is what makes this exciting. First of all, legacy IE supports the `<comment>` element that like other elements can have an id and can be retrieved via document.getElementById. However, the comment element acts entirely like an HTML comment from a parsing and rendering perspective. Thus, these elements don't affect CSS selectors. (The exception is :first-child in IE7, which does not properly ignore non-element nodes of any type.) The other problems are that IE doesn't seem to allow comment nodes to be children of select elements. However, the contents of the comment become a non-rendered textNode child of the select, so it is possible to special case this particular bug and just check the childNodes of all the select elements. Finally, IE has major issues with inserting "zero-scope" nodes, including comments, via innerHTML. I figured out that somehow putting `<script></script>` keeps IE from stripping out comment elements that follow, and these empty script tags are removed even when in the middle of content inserted via innerHTML. I added a test to double check that case.

All tests passed in Mac Firefox 2.0, 3.0, 3.6, 9.0, current Chrome, Opera, Safari, and XP IE6, 7, 8, and Windows 7 IE9.
