### PR TITLE
moves fixParentage to apply for all browsers.

### DIFF
--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -46,7 +46,8 @@
 
   K.prototype = Metamorph.prototype;
 
-  var rangeFor, htmlFunc, removeFunc, outerHTMLFunc, appendToFunc, afterFunc, prependFunc, startTagFunc, endTagFunc;
+  var rangeFor, htmlFunc, removeFunc, outerHTMLFunc, appendToFunc,
+      afterFunc, prependFunc, startTagFunc, endTagFunc, fixParentage;
 
   outerHTMLFunc = function() {
     return this.startTag() + this.innerHTML + this.endTag();
@@ -60,6 +61,40 @@
     return "<script id='" + this.end + "' type='text/x-placeholder'></script>";
   };
 
+  /**
+   * When automatically adding a tbody, some browers insert the
+   * tbody immediately before the first <tr>. Other browsers create it
+   * before the first node, no matter what.
+   *
+   * This means the the following code:
+   *
+   *     div = document.createElement("div");
+   *     div.innerHTML = "<table><script id='first'></script><tr><td>hi</td></tr><script id='last'></script></table>
+   *
+   * Might generate the following DOM:
+   *
+   *     + div
+   *       + table
+   *         - script id='first'
+   *         + tbody
+   *           + tr
+   *             + td
+   *               - "hi"
+   *           - script id='last'
+   *
+   * Which means that the two script tags, even though they were
+   * inserted at the same point in the hierarchy in the original
+   * HTML, now have different parents.
+   *
+   * This code reparents the first script tag by making it the tbody's
+   * first child.
+   **/
+  fixParentage = function(start, end) {
+    if (start.parentNode !== end.parentNode) {
+      end.parentNode.insertBefore(start, end.parentNode.firstChild);
+    }
+  };
+  
   // If we have the W3C range API, this process is relatively straight forward.
   if (supportsRange) {
 
@@ -82,9 +117,11 @@
     };
 
     htmlFunc = function(html, outerToo) {
+      fixParentage(document.getElementById(this.start), document.getElementById(this.end))
+      
       // get a range for the current metamorph object
       var range = rangeFor(this, outerToo);
-
+      
       // delete the contents of the range, which will be the
       // nodes between the starting and ending placeholder.
       range.deleteContents();
@@ -209,40 +246,6 @@
       }
 
       return start;
-    };
-
-    /**
-     * When automatically adding a tbody, Internet Explorer inserts the
-     * tbody immediately before the first <tr>. Other browsers create it
-     * before the first node, no matter what.
-     *
-     * This means the the following code:
-     *
-     *     div = document.createElement("div");
-     *     div.innerHTML = "<table><script id='first'></script><tr><td>hi</td></tr><script id='last'></script></table>
-     *
-     * Generates the following DOM in IE:
-     *
-     *     + div
-     *       + table
-     *         - script id='first'
-     *         + tbody
-     *           + tr
-     *             + td
-     *               - "hi"
-     *           - script id='last'
-     *
-     * Which means that the two script tags, even though they were
-     * inserted at the same point in the hierarchy in the original
-     * HTML, now have different parents.
-     *
-     * This code reparents the first script tag by making it the tbody's
-     * first child.
-     **/
-    var fixParentage = function(start, end) {
-      if (start.parentNode !== end.parentNode) {
-        end.parentNode.insertBefore(start, end.parentNode.firstChild);
-      }
     };
 
     htmlFunc = function(html, outerToo) {

--- a/tests/metamorph_test.js
+++ b/tests/metamorph_test.js
@@ -88,6 +88,17 @@ test("it should work inside a tbody", function() {
   ok($("#morphing").text().match(/^\s*$/), "Should leave no trace");
 });
 
+test("it should work for tables without an explicit tbody", function() {
+  var morph = Metamorph("<tr><td>HI!</td></tr>");
+  $("#qunit-fixture").html("<table id='morphing'>" + morph.outerHTML() + "</table>");
+  morph.html("<tr><td>BUH BYE!</td></tr>");
+  
+  equal($("#morphing tbody").length, 1, "Does not result in multiple tbody");
+  
+  morph.remove();
+  ok($("#morphing").text().match(/^\s*$/), "Should leave no trace");
+});
+
 test("it should work inside a tr", function() {
   var morph = Metamorph("<td>HI!</td>");
   $("#qunit-fixture").html("<table id='morphing'><tr>" + morph.outerHTML() + "</tr></table>");


### PR DESCRIPTION
I think this should fix https://github.com/tomhuda/metamorph.js/issues/10.

I'd appreciate some wider testing, though. I don't have a browser version installed where fixParentage isn't needed, although I'm guessing from the initial commit of this fix that these versions exist.
