### PR TITLE
Support for multiple metamorphs in the same DOM.

### DIFF
--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -11,7 +11,10 @@
       // This is useful if you have multiple metamorphs in a page, which happens if you
       // have a Chrome extension with a content script written in Ember, and navigate to
       // a page written in Ember.
-      prefix = (new Date()).valueOf().toString() + (Math.random() * 0x10000)|0;
+      ts = (new Date()).valueOf().toString();
+      rand = ((Math.random() * 0x10000)|0).toString();
+      prefix = ts + rand;
+
       document = window.document,
 
       // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -11,7 +11,7 @@
       // This is useful if you have multiple metamorphs in a page, which happens if you
       // have a Chrome extension with a content script written in Ember, and navigate to
       // a page written in Ember.
-      prefix = (Math.random() * 0x10000)|0;
+      prefix = (new Date()).valueOf().toString() + (Math.random() * 0x10000)|0;
       document = window.document,
 
       // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -7,6 +7,11 @@
 
   var K = function(){},
       guid = 0,
+      // At initialization, create a prefix associated with this Metamorph instance.
+      // This is useful if you have multiple metamorphs in a page, which happens if you
+      // have a Chrome extension with a content script written in Ember, and navigate to
+      // a page written in Ember.
+      prefix = (Math.random() * 0x10000)|0;
       document = window.document,
 
       // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
@@ -37,7 +42,7 @@
     }
 
     self.innerHTML = html;
-    var myGuid = 'metamorph-'+(guid++);
+    var myGuid = 'metamorph-' + prefix + '-' + (guid++);
     self.start = myGuid + '-start';
     self.end = myGuid + '-end';
 


### PR DESCRIPTION
Chrome extensions live in isolated worlds, which means that JS is not shared, but DOM is. If a Chrome extension injects a content script (written in Ember) and you are on a webpage written in Ember, metamorphs will clash.

This is a pretty exotic usecase, but I spent a few hours scratching my head about what caused the weird cross-context magic I was seeing. That said, the change seems harmless and would be pretty beneficial   for complex extension developers.

Obviously the random number from 0-10k approach is going to fail once in a while... could be smarter about it (checking the DOM for existing Metamorphs), but not sure that it's worth the complexity.
