### PR TITLE
Adds an option to disable the range API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ file a bug.
 
     // remove the morph
     morph.remove();
-    
+
     // append the morph to an existing element, useful when
     // manually creating morphs and not using a templating library
     morph.appendTo(document.getElemendById('foo'));
@@ -99,3 +99,14 @@ the code.
 Because is not always possible to insert a Metamorph directly into the DOM,
 the main initial API is `outerHTML`.
 
+## Options
+
+If you like, you can disable the range API by using an environment
+variable:
+
+    ENV = { DISABLE_RANGE_API: true }
+
+The current implementation of the range API in many browsers is slower
+than the alternative implementation inside Metamorph.js. It is a good
+idea to benchmark your application and decide whether you'd like to
+disable the range API.

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -8,9 +8,10 @@
   var K = function(){},
       guid = 0,
       document = window.document,
+      disableRange = ('undefined' === typeof ENV ? {} : ENV).DISABLE_RANGE_API,
 
       // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
-      supportsRange = document && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
+      supportsRange = (!disableRange) && document && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,
 
       // Internet Explorer prior to 9 does not allow setting innerHTML if the first element
       // is a "zero-scope" element. This problem can be worked around by making
@@ -35,7 +36,7 @@
 
   // Constructor that supports either Metamorph('foo') or new
   // Metamorph('foo');
-  // 
+  //
   // Takes a string of HTML as the argument.
 
   var Metamorph = function(html) {


### PR DESCRIPTION
This is related to my Github Issue on Ember.JS regarding the performance of the range API:

https://github.com/emberjs/ember.js/pull/3110

The range API seems to be slower across the board compared to Metamorph.js' alternative implementation. My initial PR to Ember disabled it by default, but I suspect this is not as sane a default in metamorph itself.

This adds the ability to set `ENV.DISABLE_RANGE_API = true` and have Metamorph.js not use the range API, regardless of whether the browser supports it.

If this is accepted I will revisit the Ember PR to update to the latest Metamorph.js and to set the environment variable if not previously set so it is disabled by default in Ember for the performance improvement.
