### PR TITLE
Do not require window.ENV for DISABLE_RANGE_API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ the main initial API is `outerHTML`.
 If you like, you can disable the range API by using an environment
 variable:
 
-    ENV = { DISABLE_RANGE_API: true }
+    MetamorphENV = { DISABLE_RANGE_API: true }
 
 The current implementation of the range API in many browsers is slower
 than the alternative implementation inside Metamorph.js. It is a good

--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -9,7 +9,15 @@ define("metamorph",
 
     var K = function() {},
         guid = 0,
-        disableRange = ('undefined' === typeof ENV ? {} : ENV).DISABLE_RANGE_API,
+        disableRange = (function(){
+          if ('undefined' !== typeof MetamorphENV) {
+            return MetamorphENV.DISABLE_RANGE_API;
+          } else if ('undefined' !== ENV) {
+            return ENV.DISABLE_RANGE_API;
+          } else {
+            return false;
+          }
+        })(),
 
         // Feature-detect the W3C range API, the extended check is for IE9 which only partially supports ranges
         supportsRange = (!disableRange) && typeof document !== 'undefined' && ('createRange' in document) && (typeof Range !== 'undefined') && Range.prototype.createContextualFragment,


### PR DESCRIPTION
Prioritizes `MetamorphENV` over `ENV` to disable the range API, allowing the
usage of the `ENV` global for other purposes.

This is fully backwards compatible and will simply fall back on `ENV`.

I would have preferred to use `Metamorph.ENV.DISABLE_RANGE_API` as the flag,
but the `var Metamorph` overrides (due to hoisting) any global setup at
`Metamorph` outside the closure.
