### PR TITLE
Fix check for `ENV`

### DIFF
--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -12,7 +12,7 @@ define("metamorph",
         disableRange = (function(){
           if ('undefined' !== typeof MetamorphENV) {
             return MetamorphENV.DISABLE_RANGE_API;
-          } else if ('undefined' !== ENV) {
+          } else if ('undefined' !== typeof ENV) {
             return ENV.DISABLE_RANGE_API;
           } else {
             return false;


### PR DESCRIPTION
`'undefined' !== ENV` is almost always true. Aside from being a typo, when `ENV` doesn't exist (eg. almost always when using Metamorph standalone) it would also die when trying to access `.DISABLE_RANGE_API`.
