### PR TITLE
Fix missing offset parameter on Range.setStart()

### DIFF
--- a/lib/metamorph.js
+++ b/lib/metamorph.js
@@ -146,7 +146,7 @@ define("metamorph",
 
       appendToFunc = function(node) {
         var range = document.createRange();
-        range.setStart(node);
+        range.setStart(node, 0);
         range.collapse(false);
         var frag = range.createContextualFragment(this.outerHTML());
         node.appendChild(frag);


### PR DESCRIPTION
The unit test ("it can be appended to an existing node") failed on my FF 29 (Mac OS 10.9.4) because of the missing offset parameter in Range.setStart() that is required per standard. 
My FF upgraded to 30 since and it works there without the parameter.
